### PR TITLE
Fix/typo in interface name ICopybookListner.java

### DIFF
--- a/src/main/java/net/sf/cb2xml/walker/CobolCopybookWalker.java
+++ b/src/main/java/net/sf/cb2xml/walker/CobolCopybookWalker.java
@@ -38,7 +38,7 @@ public class CobolCopybookWalker {
 	 * 
 	 * @return This CobolCopybookWalker so you can string more Tree traversals
 	 */
-	public CobolCopybookWalker walk(ICopybookListner copybookListner) {
+	public CobolCopybookWalker walk(ICopybookListener copybookListner) {
 		
 		copybookListner.startCopybook(copybook);
 		
@@ -49,7 +49,7 @@ public class CobolCopybookWalker {
 		return this;
 	}
 	
-	private void processElements(ICopybookListner listner, List<Object> elements) {
+	private void processElements(ICopybookListener listner, List<Object> elements) {
 		if (elements != null) {
 			for (Object e : elements) {
 				if (e instanceof IItem) {
@@ -73,7 +73,7 @@ public class CobolCopybookWalker {
 	 * @param listner
 	 * @param condition
 	 */
-	private void processCondition(ICopybookListner listner, ICondition condition) {
+	private void processCondition(ICopybookListener listner, ICondition condition) {
 		listner.startCondition(condition);
 		for (ICondition c : condition.getChildConditions()) {
 			processCondition(listner, c);

--- a/src/main/java/net/sf/cb2xml/walker/CopybookListnerAdapter.java
+++ b/src/main/java/net/sf/cb2xml/walker/CopybookListnerAdapter.java
@@ -5,13 +5,13 @@ import net.sf.cb2xml.def.ICopybook;
 import net.sf.cb2xml.def.IItem;
 
 /**
- * A base {@link ICopybookListner} that the you can overide
+ * A base {@link ICopybookListener} that the you can overide
  * methods as required
  * 
  * @author Bruce Martin
  *
  */
-public class CopybookListnerAdapter implements ICopybookListner {
+public class CopybookListnerAdapter implements ICopybookListener {
 
 	@Override
 	public void processComment(String Comment) {}

--- a/src/main/java/net/sf/cb2xml/walker/ICopybookListener.java
+++ b/src/main/java/net/sf/cb2xml/walker/ICopybookListener.java
@@ -4,7 +4,7 @@ import net.sf.cb2xml.def.ICondition;
 import net.sf.cb2xml.def.ICopybook;
 import net.sf.cb2xml.def.IItem;
 
-public interface ICopybookListner {
+public interface ICopybookListener {
 
 	public void processComment(String Comment);
 	

--- a/src/main/java/net/sf/cb2xml/walker/ICopybookListener.java
+++ b/src/main/java/net/sf/cb2xml/walker/ICopybookListener.java
@@ -6,16 +6,18 @@ import net.sf.cb2xml.def.IItem;
 
 public interface ICopybookListener {
 
-	public void processComment(String Comment);
-	
-	public void startCopybook(ICopybook copybook);
-	
-	public void endCopybook(ICopybook copybook);
-	
-	public void startCondition(ICondition condition);
-	public void endCondition(ICondition condition);
+    void processComment(String Comment);
 
-	public void startItem(IItem item);
-	public void endItem(IItem item);
+    void startCopybook(ICopybook copybook);
+
+    void endCopybook(ICopybook copybook);
+
+    void startCondition(ICondition condition);
+
+    void endCondition(ICondition condition);
+
+    void startItem(IItem item);
+
+    void endItem(IItem item);
 
 }


### PR DESCRIPTION
Fixing typo in interface name ICopybookListner.java 



